### PR TITLE
Correct invalid dependency name

### DIFF
--- a/src/elisp/clomacs.el
+++ b/src/elisp/clomacs.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/clojure-emacs/clomacs
 ;; Keywords: clojure, interaction
 ;; Version: 0.0.2
-;; Package-Requires: ((Emacs "24.3") (cider "0.11"))
+;; Package-Requires: ((emacs "24.3") (cider "0.11"))
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
'emacs' must be lower case. I got following error at installing this package.

```
Some dependencies were not available: Emacs
```
