### PR TITLE
Don't use obsoleted function

### DIFF
--- a/src/elisp/clomacs.el
+++ b/src/elisp/clomacs.el
@@ -103,7 +103,7 @@
     (cond
      ((functionp return-type) (funcall return-type raw-string))
      ((eq return-type :string) return-string)
-     ((eq return-type :int) (string-to-int return-string))
+     ((eq return-type :int) (string-to-number return-string))
      ((eq return-type :number) (string-to-number return-string))
      ((eq return-type :list) (read raw-string))
      ((eq return-type :char) (string-to-char return-string))


### PR DESCRIPTION
string-to-int was obsoleted function since Emacs 22.1. There is a following byte-compile warning.

```
clomacs.el:106:23:Warning: `string-to-int' is an obsolete function (as of 22.1); use `string-to-number' instead.
```
