### PR TITLE
Fix byte-compile of lambda

### DIFF
--- a/src/elisp/clomacs.el
+++ b/src/elisp/clomacs.el
@@ -47,14 +47,14 @@
          (cl-reduce
           (lambda (x y) (or x y))
           (mapcar
-           '(lambda (x)
-              (let ((repl-project-name
-                     (cadr (split-string (buffer-name x) " "))))
-                (if (equal (substring repl-project-name
-                                      0
-                                      (- (length repl-project-name) 1) )
-                           library)
-                    x)))
+           (lambda (x)
+             (let ((repl-project-name
+                    (cadr (split-string (buffer-name x) " "))))
+               (if (equal (substring repl-project-name
+                                     0
+                                     (- (length repl-project-name) 1) )
+                          library)
+                   x)))
            cider-connections)))))))
 
 (defun clomacs-launch-nrepl (library &optional sync)


### PR DESCRIPTION
```
clomacs.el:48:31:Warning: (lambda (x) ...) quoted with ' rather than with #'
```
