### PR TITLE
Fix behavior with backslash and no new line

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ and run `M-x cm-test-mdarkdown-to-html`.
 
 * [cm-test](https://github.com/kostafey/cm-test)
 * [ejc-sql](https://github.com/kostafey/ejc-sql)
+* [flower](https://github.com/PositiveTechnologies/flower)
 
 ## Requirements:
 

--- a/src/elisp/clomacs.el
+++ b/src/elisp/clomacs.el
@@ -120,9 +120,11 @@ If can't find any nREPL process return nil."
     raw-string))
 
 (defun clomacs-clean-result-string (return-string)
-  (s-replace-all '(("\\\"" . "\"")
+  (s-replace-all '(("\\\\" . "\\")
+                   ("\\\"" . "\"")
                    ("\\n"  . "\n")
-                   ("\\t"  . "\t")) return-string))
+                   ("\\t"  . "\t"))
+                 return-string))
 
 (defun clomacs-format-result (raw-string return-type)
   "Format Elisp representation of Clojure evaluation result."

--- a/test/clj/clomacs/cm_test.clj
+++ b/test/clj/clomacs/cm_test.clj
@@ -8,4 +8,5 @@
 
 (defn text-with-newlines []
   (str "Some text in the first line \n"
-       "and text in the new line."))
+       "and text in the new line. "
+       "Text with backslash and \\no new line."))

--- a/test/elisp/clomacs-test.el
+++ b/test/elisp/clomacs-test.el
@@ -77,7 +77,8 @@
   (should (equal
            (clomacs-test-text-with-newlines)
            (concat "Some text in the first line \n"
-                   "and text in the new line.")))
+                   "and text in the new line. "
+                   "Text with backslash and \\no new line.")))
 
   (clomacs-defun clomacs-test-md-wrapper
                  my-md-to-html-string


### PR DESCRIPTION
Hi @kostafey,

I have made the following changes:

* Fixed an issue with returning strings like "New User <DOMAIN\\\\NUser>" from Clojure functions defined with `clomacs-defun`.
* Added [flower](https://github.com/PositiveTechnologies/flower) project to `Projects uses clomacs` section.