### PR TITLE
Fixed misplaced docstring in clomacs-repl-buffer-name-prefix

### DIFF
--- a/src/elisp/clomacs.el
+++ b/src/elisp/clomacs.el
@@ -56,8 +56,8 @@ Clojure code directly in the same REPL."
   :type 'boolean)
 
 (defvar clomacs-repl-buffer-name-prefix
-  "First part of the CIDER nREPL buffer name: \"*cider-repl <lib-name>\"."
-  (concat (car (split-string nrepl-repl-buffer-name-template "%s")) " "))
+  (concat (car (split-string nrepl-repl-buffer-name-template "%s")) " ")
+  "First part of the CIDER nREPL buffer name: \"*cider-repl <lib-name>\".")
 
 (defun clomacs-search-connection (repl-buffer-project-name)
   "Search nREPL connection buffer.


### PR DESCRIPTION
The docstring should be last